### PR TITLE
Change url for HOT layer and enable https

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -55,7 +55,9 @@ L.OSM.MapQuestOpen = L.OSM.TileLayer.extend({
 
 L.OSM.HOT = L.OSM.TileLayer.extend({
   options: {
-    url: 'http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png',
+    url: document.location.protocol === 'https:' ?
+      'https://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png' :
+      'http://tile-{s}.openstreetmap.fr/hot/{z}/{x}/{y}.png',
     maxZoom: 20,
     subdomains: 'abc',
     attribution: '© <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors. Tiles courtesy of <a href="http://hot.openstreetmap.org/" target="_blank">Humanitarian OpenStreetMap Team</a>'


### PR DESCRIPTION
Tiles for layer HOT are now available on tile-[abc].openstreetmap.fr. This
makes it possible to enable https, as a valid certificate is used there.

This patch should also fix openstreetmap/openstreetmap-website#1092