### PR TITLE
Use https compatible names for GPS tile servers

### DIFF
--- a/leaflet-osm.js
+++ b/leaflet-osm.js
@@ -67,8 +67,8 @@ L.OSM.HOT = L.OSM.TileLayer.extend({
 L.OSM.GPS = L.OSM.TileLayer.extend({
   options: {
     url: document.location.protocol === 'https:' ?
-      'https://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png' :
-      'http://{s}.gps-tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
+      'https://gps-{s}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png' :
+      'http://gps-{s}.tile.openstreetmap.org/lines/{z}/{x}/{y}.png',
     maxZoom: 20,
     subdomains: 'abc'
   }


### PR DESCRIPTION
The gps-tile.openstreetmap.org names don't work with https as our certificate doesn't cover those names.